### PR TITLE
🔥🐙🗜🔌 Remove octopress plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,17 +6,11 @@ gem 'coderay'
 
 group :jekyll_plugins do
   gem 'octopress', '~> 3.0.0'
-  gem 'octopress-codeblock'
-  gem 'octopress-codefence'
-  gem 'octopress-debugger'
-  gem 'octopress-gist'
-  gem 'octopress-image-tag'
-  gem 'octopress-solarized'
-
   gem 'jemoji'
   gem 'jekyll-compose'
   gem 'jekyll-docs'
   gem 'jekyll-feed'
+  gem 'jekyll-gist'
   gem 'jekyll-mentions'
   gem 'jekyll-redirect-from'
   gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.4.4)
-      execjs
-    byebug (10.0.2)
     coderay (1.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.1.4)
@@ -18,7 +15,8 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    execjs (2.7.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
@@ -47,6 +45,8 @@ GEM
       jekyll (= 3.8.5)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
+    jekyll-gist (1.5.0)
+      octokit (~> 4.2)
     jekyll-mentions (1.4.1)
       html-pipeline (~> 2.3)
       jekyll (~> 3.0)
@@ -63,7 +63,6 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
-    json (2.1.0)
     kramdown (1.17.0)
     liquid (4.0.1)
     listen (3.1.5)
@@ -71,11 +70,13 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
-    method_source (0.9.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    multipart-post (2.0.0)
     nokogiri (1.10.0)
       mini_portile2 (~> 2.4.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     octopress (3.0.11)
       jekyll (>= 2.0)
       mercenary (~> 0.3.2)
@@ -84,60 +85,14 @@ GEM
       octopress-hooks (~> 2.0)
       redcarpet (~> 3.0)
       titlecase
-    octopress-autoprefixer (2.0.1)
-      autoprefixer-rails
-      jekyll (~> 3.0)
-    octopress-code-highlighter (4.3.0)
-      jekyll (~> 3.0)
-    octopress-codeblock (1.0.5)
-      octopress-code-highlighter (~> 4.2)
-    octopress-codefence (1.7.0)
-      jekyll (~> 3.0)
-      octopress-code-highlighter (~> 4.2)
-    octopress-date-format (3.0.3)
-      jekyll (>= 2.0)
-    octopress-debugger (1.0.2)
-      jekyll
-      pry-byebug
     octopress-deploy (1.3.0)
       colorator
     octopress-escape-code (2.1.1)
       jekyll (~> 3.0)
-    octopress-filters (1.4.0)
-      jekyll
-      octopress-hooks (~> 2.0)
-      rubypants-unicode
-      titlecase
-    octopress-gist (1.3.5)
-      octopress-code-highlighter (~> 4.2)
     octopress-hooks (2.6.2)
-      jekyll (>= 2.0)
-    octopress-image-tag (1.1.0)
-      jekyll
-    octopress-include-tag (1.1.3)
-      jekyll (>= 2.0)
-      octopress-tag-helpers (~> 1.0)
-    octopress-ink (1.2.1)
-      jekyll (>= 2.0)
-      octopress (~> 3.0)
-      octopress-autoprefixer
-      octopress-date-format
-      octopress-filters (~> 1.1)
-      octopress-hooks (~> 2.2)
-      octopress-include-tag (~> 1.0)
-      uglifier (~> 2.5)
-    octopress-solarized (1.1.2)
-      octopress-ink (~> 1.0)
-    octopress-tag-helpers (1.0.9)
       jekyll (>= 2.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.6.0)
-      byebug (~> 10.0)
-      pry (~> 0.10)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -145,20 +100,19 @@ GEM
     redcarpet (3.4.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
-    rubypants-unicode (0.2.5)
     safe_yaml (1.0.4)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     thread_safe (0.3.6)
     titlecase (0.1.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (2.7.2)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
 
 PLATFORMS
   ruby
@@ -169,6 +123,7 @@ DEPENDENCIES
   jekyll-compose
   jekyll-docs
   jekyll-feed
+  jekyll-gist
   jekyll-mentions
   jekyll-redirect-from
   jekyll-sitemap
@@ -176,12 +131,6 @@ DEPENDENCIES
   jemoji
   kramdown
   octopress (~> 3.0.0)
-  octopress-codeblock
-  octopress-codefence
-  octopress-debugger
-  octopress-gist
-  octopress-image-tag
-  octopress-solarized
 
 BUNDLED WITH
    2.0.1

--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,6 @@ kramdown:
   entity_output:  as_char
   toc_levels:     1..6
   smart_quotes:   lsquo,rsquo,ldquo,rdquo
-  enable_coderay: true
   coderay_line_numbers: nil
 
 syntax_highlighter: coderay

--- a/_config.yml
+++ b/_config.yml
@@ -61,14 +61,6 @@ kramdown:
 
 syntax_highlighter: coderay
 
-plugins:
-  - jemoji
-  - jekyll-mentions
-  - jekyll-redirect-from
-  - jekyll-sitemap
-  - jekyll-feed
-  - jekyll-twitter-plugin
-
 # Plugin settings
 jekyll-mentions:
   base_url: https://twitter.com

--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,7 @@ excerpt_separator: "\n\n"
 incremental: false
 
 # Markdown Processors
+# https://kramdown.gettalong.org/options.html
 kramdown:
   input:          GFM
   auto_ids:       true
@@ -55,7 +56,10 @@ kramdown:
   entity_output:  as_char
   toc_levels:     1..6
   smart_quotes:   lsquo,rsquo,ldquo,rdquo
-  enable_coderay: false
+  enable_coderay: true
+  coderay_line_numbers: nil
+
+syntax_highlighter: coderay
 
 plugins:
   - jemoji

--- a/_config.yml
+++ b/_config.yml
@@ -58,13 +58,6 @@ kramdown:
   enable_coderay: false
 
 plugins:
-  - octopress-codeblock
-  - octopress-codefence
-  - octopress-debugger
-  - octopress-gist
-  - octopress-image-tag
-  - octopress-solarized
-
   - jemoji
   - jekyll-mentions
   - jekyll-redirect-from

--- a/_drafts/twitter-plugin.markdown
+++ b/_drafts/twitter-plugin.markdown
@@ -3,9 +3,9 @@ layout: post
 title: "Twitter Plugin"
 ---
 
-{% twitter oembed https://twitter.com/DEVOPS_BORAT/status/159849628819402752 %}
+{% twitter https://twitter.com/DEVOPS_BORAT/status/159849628819402752 %}
 
-{% twitter oembed https://twitter.com/DEVOPS_BORAT/status/159849628819402752 align='right' width='350' %}
+{% twitter https://twitter.com/DEVOPS_BORAT/status/159849628819402752 align='right' width='350' %}
 
 <https://dev.twitter.com/web/embedded-tweets>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 
-  {% css_asset_tag %}
   {% include head.html %}
 
   <body>

--- a/_posts/2014-08-29-configuring-a-kst-particle-ibeacon-from-360|idev.markdown
+++ b/_posts/2014-08-29-configuring-a-kst-particle-ibeacon-from-360|idev.markdown
@@ -9,11 +9,11 @@ categories: 360idev ibeacon
 
 <img class="right" src="/images/particle_back.jpg" width="150" alt="'an image of a Particle device showing a number on the back'" title="Particle iBeacon">
 
-Everyone who attended this year's [360|iDev](http://360idev.com) in Denver was given a [Particle](https://kstechnologies.com/particle/) from KS Technologies. These are simple looking iBeacon devices that are fully configurable via KST's [Particle Accelerator](https://itunes.apple.com/us/app/particle-accelerator/id727105504?mt=8) app. KST also posted about this [awesome giveaway](https://kstechnologies.com/free-360idev-ibeacon/) on their blog.
+Everyone who attended this year's [360\|iDev](http://360idev.com) in Denver was given a [Particle](https://kstechnologies.com/particle/) from KS Technologies. These are simple looking iBeacon devices that are fully configurable via KST's [Particle Accelerator](https://itunes.apple.com/us/app/particle-accelerator/id727105504?mt=8) app. KST also posted about this [awesome giveaway](https://kstechnologies.com/free-360idev-ibeacon/) on their blog.
 
 ### tl;dr
 
-> The password scheme for the Particles given out at 360|iDev is: **360iDev123** — where _123_ is the number on the back.
+> The password scheme for the Particles given out at 360\|iDev is: **360iDev123** — where _123_ is the number on the back.
 
 <!-- more -->
 
@@ -51,7 +51,7 @@ Launch the Particle Accelerator app and tap the toggle switch in the upper right
 
 ## Password
 
-The password scheme for the Particles given out at 360|iDev is: **360iDev123** — where _123_ is the number on the back.
+The password scheme for the Particles given out at 360\|iDev is: **360iDev123** — where _123_ is the number on the back.
 
 The number on the back of my Particle is 57, so the initial password to configure it was 360iDev57 (no leading zeros).
 
@@ -63,7 +63,7 @@ You can change the password once the current password is accepted. A blank passw
 
 The UUID essentially defines a group of iBeacons. In the CoreLocation API, each `CLBeaconRegion` is identified by the UUID, and there can be many iBeacons in each region. It is also possible to monitor for multiple beacon regions at the same time.
 
-The Particles given out at 360|iDev all have their UUID set to **7D65B622-4AA8-4560-914C-502BE940BC16**. You can change this if you want. One of the UUIDs used by the AirLocate app (see below) is already in the list (E2C56DB5-DFFB-48D2-B060-D0F5A71096E0), so you can simply select this if you're wanting to test.
+The Particles given out at 360\|iDev all have their UUID set to **7D65B622-4AA8-4560-914C-502BE940BC16**. You can change this if you want. One of the UUIDs used by the AirLocate app (see below) is already in the list (E2C56DB5-DFFB-48D2-B060-D0F5A71096E0), so you can simply select this if you're wanting to test.
 
 You can also give your Particle a unique UUID. On your mac, the `uuidgen` terminal command will generate a new UUID.
 
@@ -74,7 +74,7 @@ $ uuidgen
 
 ## Major & Minor Numbers
 
-Within a single `CLBeaconRegion`, individual `CLBeacon` instances are identified by unique combinations of the `major` and `minor` numbers. The Particles from 360|iDev all have a `major` value of 1 and unique `minor` numbers that correspond to the number printed on the back of the shell.
+Within a single `CLBeaconRegion`, individual `CLBeacon` instances are identified by unique combinations of the `major` and `minor` numbers. The Particles from 360\|iDev all have a `major` value of 1 and unique `minor` numbers that correspond to the number printed on the back of the shell.
 
 # Testing your Particle
 
@@ -98,7 +98,7 @@ This sample app was released at WWDC 2013 for testing iBeacons.
 
 https://github.com/phatblat/RoyGBeacon
 
-I created a simple app which changes the background color of the screen from gray to red depending on how close you are to an iBeacon. This app will work with any brand of iBeacon, but you may need to [modify the source](https://github.com/phatblat/RoyGBeacon/blob/master/RoyGBeacon/RGBMainViewController.m#L41) to add the UUID of your beacon (the AirLocate and 360|iDev UUIDs are included).
+I created a simple app which changes the background color of the screen from gray to red depending on how close you are to an iBeacon. This app will work with any brand of iBeacon, but you may need to [modify the source](https://github.com/phatblat/RoyGBeacon/blob/master/RoyGBeacon/RGBMainViewController.m#L41) to add the UUID of your beacon (the AirLocate and 360\|iDev UUIDs are included).
 
 ## BTLExplorer
 

--- a/_posts/2014-08-29-configuring-a-kst-particle-ibeacon-from-360|idev.markdown
+++ b/_posts/2014-08-29-configuring-a-kst-particle-ibeacon-from-360|idev.markdown
@@ -7,7 +7,7 @@ published: true
 categories: 360idev ibeacon
 ---
 
-{% img right /images/particle_back.jpg 150 'an image of a Particle device showing a number on the back' title:'Particle iBeacon' %}
+<img class="right" src="/images/particle_back.jpg" width="150" alt="'an image of a Particle device showing a number on the back'" title="Particle iBeacon">
 
 Everyone who attended this year's [360|iDev](http://360idev.com) in Denver was given a [Particle](https://kstechnologies.com/particle/) from KS Technologies. These are simple looking iBeacon devices that are fully configurable via KST's [Particle Accelerator](https://itunes.apple.com/us/app/particle-accelerator/id727105504?mt=8) app. KST also posted about this [awesome giveaway](https://kstechnologies.com/free-360idev-ibeacon/) on their blog.
 
@@ -29,9 +29,9 @@ After you pop the top off, use a pen to push the coin battery down toward the le
 
 When you put the battery back in, the positive (+) side goes up.
 
-{% img /images/particle_opening_slot.png 200 'an image of opening the Particle using a coin' title:'Particle shell opening slot' %}
-{% img /images/particle_battery.jpg 200 'an image of the Particle battery being removed' title:'Particle battery removal' %}
-{% img /images/particle_open.jpg 200 'an image of the Particle internals' title:'Particle open with battery out' %}
+<img src="/images/particle_opening_slot.png" width="200" alt="'an image of opening the Particle using a coin'" title="Particle shell opening slot">
+<img src="/images/particle_battery.jpg" width="200" alt="'an image of the Particle battery being removed'" title="Particle battery removal">
+<img src="/images/particle_open.jpg" width="200" alt="'an image of the Particle internals'" title="Particle open with battery out">
 
 # Config Prep
 
@@ -45,7 +45,7 @@ Before continuing, you'll need the following:
 
 # Configuration
 
-{% img right /images/particle_accelerator_app.png 200 'an image of the Particle Accelerator app showing my device' title:'Particle Accelerator app' %}
+<img class="right" src="/images/particle_accelerator_app.png" width="200" alt="'an image of the Particle Accelerator app showing my device'" title="Particle Accelerator app">
 
 Launch the Particle Accelerator app and tap the toggle switch in the upper right corner to enable scanning. Once your Particle appears, tap on it to bring up the configuration screen.
 
@@ -68,7 +68,7 @@ The Particles given out at 360|iDev all have their UUID set to **7D65B622-4AA8-4
 You can also give your Particle a unique UUID. On your mac, the `uuidgen` terminal command will generate a new UUID.
 
 ```
-$ uuidgen                                                                                            
+$ uuidgen
 30FDAAFB-C585-4DA5-81F9-2CA293EFCF93
 ```
 
@@ -78,7 +78,7 @@ Within a single `CLBeaconRegion`, individual `CLBeacon` instances are identified
 
 # Testing your Particle
 
-{% img right /images/particle_detector_app.png 170 'an image of the Particle Detector app showing my device' title:'Particle Detector app' %}
+<img class="right" src="/images/particle_detector_app.png" width="170" alt="'an image of the Particle Detector app showing my device'" title="Particle Detector app">
 
 ## Particle Detector
 
@@ -92,7 +92,7 @@ https://developer.apple.com/LIBRARY/ios/samplecode/AirLocate/Introduction/Intro.
 
 This sample app was released at WWDC 2013 for testing iBeacons.
 
-{% img right /images/roygbeacon.png 170 'an image of Roy G. Beacon app with a red background showing my device' title:'RoyGBeacon app' %}
+<img class="right" src="/images/roygbeacon.png" width="170" alt="'an image of Roy G. Beacon app with a red background showing my device'" title="RoyGBeacon app">
 
 ## RoyGBeacon
 

--- a/_posts/2014-09-14-git-sparse-checkout.markdown
+++ b/_posts/2014-09-14-git-sparse-checkout.markdown
@@ -88,7 +88,7 @@ The `sparse-checkout` file uses the same syntax as `.gitignore`. The following l
 
 After changing the `.git/info/sparse-checkout` file, do a `checkout <branch>` (`checkout source` in the case of Octopress) in order to update the work tree with this new "view" of files.
 
-{% img center /images/git-sparse-checkout-markdown.png 'an image from OS X Terminal showing a tree of only markdown files' title:'Sparse checkout of only markdown files' %}
+<img class="center" src="/images/git-sparse-checkout-markdown.png" alt="'an image from OS X Terminal showing a tree of only markdown files'" title="Sparse checkout of only markdown files">
 
 After getting this far into this feature of git, I may end up using it to help reduce the filesystem noise from Octopress. It always takes me a few minutes to remember where everything goes.
 

--- a/_posts/2014-09-14-git-sparse-checkout.markdown
+++ b/_posts/2014-09-14-git-sparse-checkout.markdown
@@ -17,7 +17,8 @@ The exercise here is to get a copy of just the images from my blog. Not terribly
 
 ## The Code
 
-{% gist a5caa3bb3a3784f03000 sparse_checkout.sh [options] %}
+{% gist a5caa3bb3a3784f03000 sparse_checkout.sh %}
+
 
 I'm going to walk through this script with the lines a bit out of order; variables will be interspersed with the code that uses them. I generally build scripts with all the variables at the top to make it easy to see what can be tweaked, but having them inline makes the logic easier to follow.
 

--- a/_posts/2015-02-04-communicating-between-an-ios-app-and-a-watch-extension.markdown
+++ b/_posts/2015-02-04-communicating-between-an-ios-app-and-a-watch-extension.markdown
@@ -8,7 +8,7 @@ categories:  ios watchkit architecture
 
 I'm building a WatchKit extension for an existing iOS app and have been experimenting with the "plumbing" between the two. Watch extensions are different animals than other iOS 8 extensions, but there is a lot of overlap in this area. Today I made a diagram to show the options of getting data to the iPhone app from the Watch and vice-versa.
 
-{% img /images/apple_watch_communication.png 'a flowchart diagram' title:'Communicating between an iOS App and a Watch Extension' %}
+<img src="/images/apple_watch_communication.png" alt="'a flowchart diagram'" title="Communicating between an iOS App and a Watch Extension">
 
 This is simply a graphical representation of the summary presented in a [Developer Forums thread](https://devforums.apple.com/thread/256667?tstart=0).
 

--- a/_posts/2016-01-03-ipro-review.markdown
+++ b/_posts/2016-01-03-ipro-review.markdown
@@ -10,7 +10,7 @@ tags: ipad, review
 
 Talked with my dad earlier today and was raving to him how much I love the new iPad Pro. I've used every iPad since the original but this is the first one that has the potential to replace a laptop IMHO, at least for casual users or casual use by pro users. Case in point: it's pretty much all I've been using for the last week and a half while I've been laid up at home recovering from my [accident]({% post_url 2016-01-06-accident %}). The only things I've broken out my MacBook for are for Xcode, a second set of browser tabs for some Black Friday and Cyber Monday shopping and to do some general maintenance on my development tools.
 
-{% twitter oembed https://twitter.com/phatblat/status/674332881938833408 align='center' %}
+{% twitter https://twitter.com/phatblat/status/674332881938833408 align='center' %}
 
 So, what's so great about this? It's "just" a bigger iPad, right? That's exactly why!
 

--- a/_posts/2016-01-05-jekyll-twitter-plugin.markdown
+++ b/_posts/2016-01-05-jekyll-twitter-plugin.markdown
@@ -20,8 +20,9 @@ The first plugin that I found when looking for this functionality is the obsolet
 
 Syntax:
 
-```liquid class:"wrap"
-{% tweet https://twitter.com/DEVOPS_BORAT/statuses/159849628819402752 %}
+<!-- https://stackoverflow.com/a/5866429/39207 -->
+```liquid
+{{ "{% tweet https://twitter.com/DEVOPS_BORAT/statuses/159849628819402752 " }}%}
 ```
 
 ## jekyll-twitter-plugin
@@ -30,11 +31,11 @@ Based on the tweet-tag plugin, the [jekyll-twitter-plugin](https://github.com/ro
 
 The syntax is very similar:
 
-```liquid class:"wrap"
-{% twitter oembed https://twitter.com/DepressedDarth/status/683671063855759360 %}
+```liquid
+{{ "{% twitter https://twitter.com/DepressedDarth/status/683671063855759360 " }}%}
 ```
 
-{% twitter oembed https://twitter.com/DepressedDarth/status/683671063855759360 %}
+{% twitter https://twitter.com/DepressedDarth/status/683671063855759360 %}
 
 
 ### Ad Blockers
@@ -48,11 +49,11 @@ Note: if you're blocking the "Twitter Button" tracker with a browser plugin like
 
 There are a few formatting options, such as `align` and `width`:
 
-```liquid class:"wrap"
-{% twitter oembed https://twitter.com/DepressedDarth/status/684318431227727872 align='center' width='220' %}
+```liquid
+{{ "{% twitter https://twitter.com/DepressedDarth/status/684318431227727872 align='center' width='220' " }}%}
 ```
 
-{% twitter oembed https://twitter.com/DepressedDarth/status/684318431227727872 align='center' width='220' %}
+{% twitter https://twitter.com/DepressedDarth/status/684318431227727872 align='center' width='220' %}
 
 The `width` parameter must be between 220 and 550 inclusive and seems to have no effect on the text-only rendering of the tweet.
 
@@ -61,11 +62,11 @@ The `width` parameter must be between 220 and 550 inclusive and seems to have no
 
 This plugin will pass along any extra parameters like `hide_media` to the [oembed API](https://dev.twitter.com/rest/reference/get/statuses/oembed) for further customization.
 
-```liquid class:"wrap"
-{% twitter oembed https://twitter.com/DepressedDarth/status/684318431227727872 hide_media='true' %}
+```liquid
+{{ "{% twitter https://twitter.com/DepressedDarth/status/684318431227727872 hide_media='true' " }}%}
 ```
 
-{% twitter oembed https://twitter.com/DepressedDarth/status/684318431227727872 hide_media='true' %}
+{% twitter https://twitter.com/DepressedDarth/status/684318431227727872 hide_media='true' %}
 
 Text rendering of the tweet is unaffected by `hide_media` because it only includes a link by default.
 
@@ -84,7 +85,7 @@ The challenge with environment variables is making sure they are defined wheneve
 
 Here is a very simple untracked file based solution. I created an `.env` file containing each environment variable on a separate line like so:
 
-```bash class:"wrap"
+```bash
 TWITTER_CONSUMER_KEY=...
 TWITTER_CONSUMER_SECRET=...
 TWITTER_ACCESS_TOKEN=...
@@ -93,7 +94,7 @@ TWITTER_ACCESS_TOKEN_SECRET=...
 
 The values in this file are then loaded into the environment for the Jekyll process on the fly using the `env` command.
 
-```bash class:"wrap"
+```bash
 env $(cat .env | xargs) bundle exec jekyll serve
 ```
 
@@ -105,7 +106,7 @@ One caveat is that this command now generates an error if there is not an `.env`
 
 Note that the above environment variables can be loaded into the shell using the builtin `export` command instead of `env`. That is fine for testing, but leaves them defined in the environment for any other process to read.
 
-```bash class:"wrap"
+```bash
 echo $TWITTER_CONSUMER_KEY
 ```
 

--- a/_posts/2016-04-29-testing-iboutlets-and-ibactions-with-curried-functions-in-swift.markdown
+++ b/_posts/2016-04-29-testing-iboutlets-and-ibactions-with-curried-functions-in-swift.markdown
@@ -249,7 +249,7 @@ Versions of these outlet/action assertion functions using the older, cleaner syn
 Apple, you can take my sweet curry, but you'll never take my Sriracha.
 
 <center>
-{% img /images/sriracha-clip-on-bag.jpg 400 'Small Sriracha bottle attached to messenger bag' title:'Sriracha2Go' %}
+<img src="/images/sriracha-clip-on-bag.jpg" width="400" alt="'Small Sriracha bottle attached to messenger bag'" title="Sriracha2Go">
 </center>
 
 <br>

--- a/_posts/2016-05-10-uisearchcontroller.markdown
+++ b/_posts/2016-05-10-uisearchcontroller.markdown
@@ -31,7 +31,7 @@ We're going to reserve some space in the UI using a "container" view[^container-
 [^container-view]: Nothing as fancy as [View Controller Containment](https://www.objc.io/issues/1-view-controllers/containment-view-controller/). Just a simple `UIView` which we'll be using as the parent view for the `UISearchBar`.
 
 <center>
-{% img /images/uisearchcontroller-main-scene.png 300 'Main scene showing search bar container view' title:'Main scene' %}
+<img src="/images/uisearchcontroller-main-scene.png" width="300" alt="'Main scene showing search bar container view'" title="Main scene">
 </center>
 
 ## Search Results Controller
@@ -39,7 +39,7 @@ We're going to reserve some space in the UI using a "container" view[^container-
 The search results controller is just a simple `UITableViewController` with each cell displaying a single Swift keyword.
 
 <center>
-{% img /images/uisearchcontroller-search-results.png 300 'Search results table showing a list of swift keywords' title:'Search results' %}
+<img src="/images/uisearchcontroller-search-results.png" width="300" alt="'Search results table showing a list of swift keywords'" title="Search results">
 </center>
 
 ## Search Controller
@@ -81,7 +81,7 @@ It's common to also make the search results controller the `searchResultsUpdater
 
 
 <center>
-{% img /images/uisearchcontroller-no-results.png 300 'Empty search results screen' title:'Empty search results' %}
+<img src="/images/uisearchcontroller-no-results.png" width="300" alt="'Empty search results screen'" title="Empty search results">
 </center>
 
 Instead the "main" view controller will be the `searchResultsUpdater` and it will pass the current `searchTerm` into the search results controller. The search results controller will take care of filtering and return the number of results displayed.


### PR DESCRIPTION
This removes all nonessential octopress plugins, switching to their equivalent jekyll versions. It is a necessary precursor to #3 